### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -45,7 +45,7 @@ $ c0f --help
 == Using c0f
 
 First you will want to use candump from can-utils (on linux) to record some CAN traffic from
-a vehicle that is turned completed on (not just in Auxilary mode).  You will want at least 2000
+a vehicle that is turned completed on (not just in Auxiliary mode).  You will want at least 2000
 packets...which should only take a few seconds but more won't hurt anything.  Have candump
 log this to a file.  For instance
 


### PR DESCRIPTION
zombieCraig, I've corrected a typographical error in the documentation of the [c0f](https://github.com/zombieCraig/c0f) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
